### PR TITLE
Add ECH in doc

### DIFF
--- a/docs/Analyzers.md
+++ b/docs/Analyzers.md
@@ -224,7 +224,8 @@ Example for blocking all SSH connections:
         772,
         771
       ],
-      "version": 771
+      "version": 771,
+      "ech": true
     },
     "resp": {
       "cipher": 4866,


### PR DESCRIPTION
Extension 0xfe0d should be the only information that can be extracted. We can use this to block ECH connections. If any other information can still be parsed, please report to IETF 😇