### PR TITLE
Add OICQAnalyzer

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -115,6 +115,10 @@ workers:
 - name: block CN geoip
   action: block
   expr: geoip(string(ip.dst), "cn")
+
+- name: block qq number 1145141919 communication
+  action: block
+  expr: oicq != nil && oicq.number == 1145141919
 ```
 
 #### サポートされるアクション

--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ to [Expr Language Definition](https://expr-lang.org/docs/language-definition).
 - name: block CN geoip
   action: block
   expr: geoip(string(ip.dst), "cn")
+
+- name: block qq number 1145141919 communication
+  action: block
+  expr: oicq != nil && oicq.number == 1145141919
 ```
 
 #### Supported actions

--- a/README.zh.md
+++ b/README.zh.md
@@ -114,6 +114,10 @@ workers:
 - name: block CN geoip
   action: block
   expr: geoip(string(ip.dst), "cn")
+
+- name: block qq number 1145141919 communication
+  action: block
+  expr: oicq != nil && oicq.number == 1145141919
 ```
 
 #### 支持的 action

--- a/analyzer/udp/oicq.go
+++ b/analyzer/udp/oicq.go
@@ -1,0 +1,87 @@
+package udp
+
+import (
+	"encoding/binary"
+	"github.com/apernet/OpenGFW/analyzer"
+)
+
+const (
+	OICQPacketStartFlag = 0x02
+	OICQPacketEndFlag   = 0x03
+	OICQ4QQVersion      = 0x03905
+)
+
+// OICQAnalyzer OICQ is an IM Software protocol, Usually used by QQ
+var (
+	_ analyzer.UDPAnalyzer = (*OICQAnalyzer)(nil)
+)
+
+type OICQAnalyzer struct{}
+
+func (a *OICQAnalyzer) Name() string {
+	return "oicq"
+}
+
+func (a *OICQAnalyzer) Limit() int {
+	return 0
+}
+
+func (a *OICQAnalyzer) NewUDP(info analyzer.UDPInfo, logger analyzer.Logger) analyzer.UDPStream {
+	return &OICQStream{logger: logger}
+}
+
+type OICQStream struct {
+	logger analyzer.Logger
+}
+
+func (s *OICQStream) Feed(rev bool, data []byte) (u *analyzer.PropUpdate, done bool) {
+	m := parseOICQMessage(data)
+	if m == nil {
+		return nil, true
+	}
+	return &analyzer.PropUpdate{
+		Type: analyzer.PropUpdateReplace,
+		M:    m,
+	}, true
+}
+
+func (s *OICQStream) Close(limited bool) *analyzer.PropUpdate {
+	return nil
+}
+
+func parseOICQMessage(data []byte) analyzer.PropMap {
+	/* preInfo struct
+	+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+
+	|Flag |  Version  | Command   | Sequence  |         Number        |
+	+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+
+	|          ................Data................(Dynamic Len)	  |
+	+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+
+	*/
+	// At least 8 bytes
+	if len(data) < 7 {
+		return nil
+	}
+	if data[0] != OICQPacketStartFlag { // OICQ Packet Start With 0x02
+		return nil
+	}
+	if binary.BigEndian.Uint16(data[1:3]) != OICQ4QQVersion { // OICQ Version 0x03905
+		return nil
+	}
+	if data[len(data)-1] != OICQPacketEndFlag { // OICQ Packet End With 0x03
+		return nil
+	}
+	data = data[3:]
+	m := analyzer.PropMap{
+		"command": binary.BigEndian.Uint16(data[2:4]),
+		"seq":     binary.BigEndian.Uint16(data[4:6]),
+		"number":  0,
+	}
+	data = data[4:]
+	if len(data) < 5 {
+		// Valid OICQ packet, but no Number field
+		return m
+	}
+	m["number"] = binary.BigEndian.Uint32(data[0:4])
+	// Valid OICQ packet with Number field
+	return m
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -92,6 +92,7 @@ var analyzers = []analyzer.Analyzer{
 	&tcp.TLSAnalyzer{},
 	&tcp.TrojanAnalyzer{},
 	&udp.DNSAnalyzer{},
+	&udp.OICQAnalyzer{},
 	&udp.WireGuardAnalyzer{},
 }
 


### PR DESCRIPTION
Add OICQAnalyzer(For QQ):

usage:
```
- name: all oicq traffic
  action: block
  expr: oicq != nil

- name: oicq and QQ number is 114514
  action: block
  expr: oicq != nil && oicq.number == 114514
```

result:
When applying the rules `oicq and QQ number is 114514`, the user with the number 114514 cannot log in to QQ, or send messages successfully to the QQ server even if he is already logged in.

