### PR TITLE
fix: incorrect "virgin" handling causing rules with only built-in keywords to fail

### DIFF
--- a/engine/udp.go
+++ b/engine/udp.go
@@ -61,12 +61,6 @@ func (f *udpStreamFactory) New(ipFlow, udpFlow gopacket.Flow, udp *layers.UDP, u
 	rs := f.Ruleset
 	f.RulesetMutex.RUnlock()
 	ans := analyzersToUDPAnalyzers(rs.Analyzers(info))
-	if len(ans) == 0 {
-		uc.Verdict = udpVerdictAcceptStream
-		f.Logger.UDPStreamAction(info, ruleset.ActionAllow, true)
-		// a udpStream with no activeEntries is a no-op
-		return &udpStream{finalVerdict: udpVerdictAcceptStream}
-	}
 	// Create entries for each analyzer
 	entries := make([]*udpStreamEntry, 0, len(ans))
 	for _, a := range ans {
@@ -167,7 +161,7 @@ type udpStream struct {
 	ruleset       ruleset.Ruleset
 	activeEntries []*udpStreamEntry
 	doneEntries   []*udpStreamEntry
-	finalVerdict  udpVerdict
+	lastVerdict   udpVerdict
 }
 
 type udpStreamEntry struct {
@@ -178,10 +172,13 @@ type udpStreamEntry struct {
 }
 
 func (s *udpStream) Accept(udp *layers.UDP, rev bool, uc *udpContext) bool {
-	if len(s.activeEntries) > 0 {
+	if len(s.activeEntries) > 0 || s.virgin {
+		// Make sure every stream matches against the ruleset at least once,
+		// even if there are no activeEntries, as the ruleset may have built-in
+		// properties that need to be matched.
 		return true
 	} else {
-		uc.Verdict = s.finalVerdict
+		uc.Verdict = s.lastVerdict
 		return false
 	}
 }
@@ -227,17 +224,17 @@ func (s *udpStream) Feed(udp *layers.UDP, rev bool, uc *udpContext) {
 		}
 		if action != ruleset.ActionMaybe {
 			verdict, final := actionToUDPVerdict(action)
+			s.lastVerdict = verdict
 			uc.Verdict = verdict
 			s.logger.UDPStreamAction(s.info, action, false)
 			if final {
-				s.finalVerdict = verdict
 				s.closeActiveEntries()
 			}
 		}
 	}
 	if len(s.activeEntries) == 0 && uc.Verdict == udpVerdictAccept {
 		// All entries are done but no verdict issued, accept stream
-		s.finalVerdict = udpVerdictAcceptStream
+		s.lastVerdict = udpVerdictAcceptStream
 		uc.Verdict = udpVerdictAcceptStream
 		s.logger.UDPStreamAction(s.info, ruleset.ActionAllow, true)
 	}


### PR DESCRIPTION
Closes https://github.com/apernet/OpenGFW/issues/59