### PR TITLE
Add CIDR support for expr

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -124,6 +124,10 @@ workers:
 - name: block CN geoip
   action: block
   expr: geoip(string(ip.dst), "cn")
+
+- name: block cidr
+  action: block
+  expr: cidr(string(ip.dst), "192.168.0.0/16")
 ```
 
 #### サポートされるアクション

--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ to [Expr Language Definition](https://expr-lang.org/docs/language-definition).
 - name: block CN geoip
   action: block
   expr: geoip(string(ip.dst), "cn")
+
+- name: block cidr
+  action: block
+  expr: cidr(string(ip.dst), "192.168.0.0/16")
 ```
 
 #### Supported actions

--- a/README.zh.md
+++ b/README.zh.md
@@ -125,6 +125,10 @@ workers:
 - name: block CN geoip
   action: block
   expr: geoip(string(ip.dst), "cn")
+
+- name: block cidr
+  action: block
+  expr: cidr(string(ip.dst), "192.168.0.0/16")
 ```
 
 #### 支持的 action

--- a/ruleset/builtins/cidr.go
+++ b/ruleset/builtins/cidr.go
@@ -1,0 +1,18 @@
+package builtins
+
+import (
+	"net"
+)
+
+func MatchCIDR(ip string, cidr *net.IPNet) bool {
+	ipAddr := net.ParseIP(ip)
+	if ipAddr == nil {
+		return false
+	}
+	return cidr.Contains(ipAddr)
+}
+
+func CompileCIDR(cidr string) (*net.IPNet, error) {
+	_, ipNet, err := net.ParseCIDR(cidr)
+	return ipNet, err
+}


### PR DESCRIPTION
I add CIDR support for expr. Here's example:

```yaml
- name: block cidr
  action: block
  expr: cidr(string(ip.dst), "192.168.0.0/16")
```

I use `Patch` to parse CIDR string at expr compile time, for this avoids the use of lock and repeated parsing of the CIDR string.