### PR TITLE
fix: engine exit with "netlink receive: recvmsg: no buffer space available" when too many packets hit NFQUEUE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/zap v1.26.0
 	golang.org/x/crypto v0.19.0
+	golang.org/x/sys v0.17.0
 	google.golang.org/protobuf v1.31.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -43,7 +44,6 @@ require (
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/sync v0.5.0 // indirect
-	golang.org/x/sys v0.17.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 )

--- a/io/nfqueue.go
+++ b/io/nfqueue.go
@@ -12,6 +12,7 @@ import (
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/florianl/go-nfqueue"
 	"github.com/mdlayher/netlink"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -152,6 +153,12 @@ func (n *nfqueuePacketIO) Register(ctx context.Context, cb PacketCallback) error
 			return okBoolToInt(cb(p, nil))
 		},
 		func(e error) int {
+			if opErr := (*netlink.OpError)(nil); errors.As(e, &opErr) {
+				if errors.Is(opErr.Err, unix.ENOBUFS) {
+					// Kernel buffer temporarily full, ignore
+					return 0
+				}
+			}
 			return okBoolToInt(cb(nil, e))
 		})
 	if err != nil {


### PR DESCRIPTION
When flood pinging the machine running OpenGFW with `ping -f`, the engine would exit with the following error.

```
2024-02-26T15:41:51+08:00       INFO    engine exited   {"error": "netlink receive: recvmsg: no buffer space available"}
```

This error can be safely ignored, the OpenGFW will continue working and everything will be back to normal once the flood ping is end.