### PR TITLE
fix: cannot trap sigkill -9

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -279,7 +279,7 @@ func runMain(cmd *cobra.Command, args []string) {
 	go func() {
 		// Graceful shutdown
 		shutdownChan := make(chan os.Signal)
-		signal.Notify(shutdownChan, os.Interrupt, os.Kill)
+		signal.Notify(shutdownChan, os.Interrupt, os.Kill, syscall.SIGTERM)
 		<-shutdownChan
 		logger.Info("shutting down gracefully...")
 		cancelFunc()


### PR DESCRIPTION
### summary

App cannot sigkill -9. we can trap sigterm -15, `kill` command send sigterm -15 signal by default.

https://en.wikipedia.org/wiki/Signal_(IPC)#SIGKILL

![image](https://github.com/apernet/OpenGFW/assets/3785409/bdd9f2d2-3d77-4f80-9f13-149a5be15d47)
