### PR TITLE
feat: netlink queueNum/table config options

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -173,13 +173,13 @@ type cliConfig struct {
 }
 
 type cliConfigIO struct {
-	QueueSize   uint32 `mapstructure:"queueSize"`
-	QueueNum    uint16 `mapstructure:"queueNum"`
-	Table       string `mapstructure:"table"`
-	ReadBuffer  int    `mapstructure:"rcvBuf"`
-	WriteBuffer int    `mapstructure:"sndBuf"`
-	Local       bool   `mapstructure:"local"`
-	RST         bool   `mapstructure:"rst"`
+	QueueSize   uint32  `mapstructure:"queueSize"`
+	QueueNum    *uint16 `mapstructure:"queueNum"`
+	Table       string  `mapstructure:"table"`
+	ReadBuffer  int     `mapstructure:"rcvBuf"`
+	WriteBuffer int     `mapstructure:"sndBuf"`
+	Local       bool    `mapstructure:"local"`
+	RST         bool    `mapstructure:"rst"`
 }
 
 type cliConfigReplay struct {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -173,13 +173,16 @@ type cliConfig struct {
 }
 
 type cliConfigIO struct {
-	QueueSize   uint32  `mapstructure:"queueSize"`
-	QueueNum    *uint16 `mapstructure:"queueNum"`
-	Table       string  `mapstructure:"table"`
-	ReadBuffer  int     `mapstructure:"rcvBuf"`
-	WriteBuffer int     `mapstructure:"sndBuf"`
-	Local       bool    `mapstructure:"local"`
-	RST         bool    `mapstructure:"rst"`
+	QueueSize      uint32  `mapstructure:"queueSize"`
+	QueueNum       *uint16 `mapstructure:"queueNum"`
+	Table          string  `mapstructure:"table"`
+	ConnMarkAccept uint32  `mapstructure:"connMarkAccept"`
+	ConnMarkDrop   uint32  `mapstructure:"connMarkDrop"`
+
+	ReadBuffer  int  `mapstructure:"rcvBuf"`
+	WriteBuffer int  `mapstructure:"sndBuf"`
+	Local       bool `mapstructure:"local"`
+	RST         bool `mapstructure:"rst"`
 }
 
 type cliConfigReplay struct {
@@ -218,13 +221,16 @@ func (c *cliConfig) fillIO(config *engine.Config) error {
 	} else {
 		// Setup IO for nfqueue
 		ioImpl, err = io.NewNFQueuePacketIO(io.NFQueuePacketIOConfig{
-			QueueSize:   c.IO.QueueSize,
+			QueueSize:      c.IO.QueueSize,
+			QueueNum:       c.IO.QueueNum,
+			Table:          c.IO.Table,
+			ConnMarkAccept: c.IO.ConnMarkAccept,
+			ConnMarkDrop:   c.IO.ConnMarkDrop,
+
 			ReadBuffer:  c.IO.ReadBuffer,
 			WriteBuffer: c.IO.WriteBuffer,
 			Local:       c.IO.Local,
 			RST:         c.IO.RST,
-			QueueNum:    c.IO.QueueNum,
-			Table:       c.IO.Table,
 		})
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -174,6 +174,8 @@ type cliConfig struct {
 
 type cliConfigIO struct {
 	QueueSize   uint32 `mapstructure:"queueSize"`
+	QueueNum    uint16 `mapstructure:"queueNum"`
+	Table       string `mapstructure:"table"`
 	ReadBuffer  int    `mapstructure:"rcvBuf"`
 	WriteBuffer int    `mapstructure:"sndBuf"`
 	Local       bool   `mapstructure:"local"`
@@ -221,6 +223,8 @@ func (c *cliConfig) fillIO(config *engine.Config) error {
 			WriteBuffer: c.IO.WriteBuffer,
 			Local:       c.IO.Local,
 			RST:         c.IO.RST,
+			QueueNum:    c.IO.QueueNum,
+			Table:       c.IO.Table,
 		})
 	}
 

--- a/io/nfqueue.go
+++ b/io/nfqueue.go
@@ -227,7 +227,7 @@ func (n *nfqueuePacketIO) Register(ctx context.Context, cb PacketCallback) error
 		if n.ipt4 != nil {
 			err = n.setupIpt(n.local, n.rst, false)
 		} else {
-			err = n.setupNft(n.local, n.rst, false, n.queueNum)
+			err = n.setupNft(n.local, n.rst, false)
 		}
 		if err != nil {
 			return err
@@ -287,7 +287,7 @@ func (n *nfqueuePacketIO) Close() error {
 		if n.ipt4 != nil {
 			_ = n.setupIpt(n.local, n.rst, true)
 		} else {
-			_ = n.setupNft(n.local, n.rst, true, n.queueNum)
+			_ = n.setupNft(n.local, n.rst, true)
 		}
 		n.rSet = false
 	}
@@ -299,8 +299,8 @@ func (n *nfqueuePacketIO) SetCancelFunc(cancelFunc context.CancelFunc) error {
 	return nil
 }
 
-func (n *nfqueuePacketIO) setupNft(local, rst, remove bool, nfqueueNum int) error {
-	rules, err := generateNftRules(local, rst, nfqueueNum, n.table)
+func (n *nfqueuePacketIO) setupNft(local, rst, remove bool) error {
+	rules, err := generateNftRules(local, rst, n.queueNum, n.table)
 	if err != nil {
 		return err
 	}

--- a/io/nfqueue.go
+++ b/io/nfqueue.go
@@ -110,7 +110,7 @@ type nfqueuePacketIO struct {
 
 type NFQueuePacketIOConfig struct {
 	QueueSize   uint32
-	QueueNum    uint16
+	QueueNum    *uint16
 	Table       string
 	ReadBuffer  int
 	WriteBuffer int
@@ -122,8 +122,9 @@ func NewNFQueuePacketIO(config NFQueuePacketIOConfig) (PacketIO, error) {
 	if config.QueueSize == 0 {
 		config.QueueSize = nfqueueDefaultQueueSize
 	}
-	if config.QueueNum == 0 {
-		config.QueueNum = nfqueueDefaultQueueNum
+	if config.QueueNum == nil {
+		queueNum := uint16(nfqueueDefaultQueueNum)
+		config.QueueNum = &queueNum
 	}
 	if config.Table == "" {
 		config.Table = nftDefaultTable
@@ -142,7 +143,7 @@ func NewNFQueuePacketIO(config NFQueuePacketIOConfig) (PacketIO, error) {
 		}
 	}
 	n, err := nfqueue.Open(&nfqueue.Config{
-		NfQueue:      config.QueueNum,
+		NfQueue:      *config.QueueNum,
 		MaxPacketLen: nfqueueMaxPacketLen,
 		MaxQueueLen:  config.QueueSize,
 		Copymode:     nfqueue.NfQnlCopyPacket,
@@ -169,7 +170,7 @@ func NewNFQueuePacketIO(config NFQueuePacketIOConfig) (PacketIO, error) {
 		n:        n,
 		local:    config.Local,
 		rst:      config.RST,
-		queueNum: int(config.QueueNum),
+		queueNum: int(*config.QueueNum),
 		table:    config.Table,
 		ipt4:     ipt4,
 		ipt6:     ipt6,


### PR DESCRIPTION
OpenGFW currently hard codes the netlink table name and queue number which causes conflict errors such as `could not bind to requested queue 100: netlink receive: operation not permitted` when running multiple instances of the application on the same host using different rulesets.

This pull request exposes configuration options that allow the user to set a unique table name and queueNum if they want to run multiple instances, for example:
```
io:
  queueSize: 1024
  table: 'opengfw2' # use a unique table if you want to run multiple instances
  queueNum: 102 # use a unique queue if you want to run multiple instances
  local: true # set to false if you want to run OpenGFW on FORWARD chain
  ```
Setting a unique table name will help prevent one instance from removing another already running application's rules when it exits.